### PR TITLE
[SASS-10601] Add FS for EMA Supporting Agents and authorisation logic

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -24,7 +24,7 @@ class Module extends AbstractModule {
 
   override def configure(): Unit = {
 
-    bind(classOf[AppConfig]).asEagerSingleton()
+    bind(classOf[AppConfig]).to(classOf[AppConfigImpl]).asEagerSingleton()
     bind(classOf[Clock]).toInstance(Clock.systemDefaultZone.withZone(ZoneOffset.UTC))
   }
 }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -18,6 +18,6 @@ package models
 
 import models.common.Mtditid
 
-case class User(mtditid: String, arn: Option[String]) {
+case class User(mtditid: String, arn: Option[String], isSecondaryAgent: Boolean = false) {
   def getMtditid: Mtditid = Mtditid(mtditid)
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -88,3 +88,7 @@ microservice {
     }
   }
 }
+
+feature-switch {
+  ema-supporting-agents-enabled = true
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.22.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.3")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.0.9")

--- a/test/actions/AuthorisedActionSpec.scala
+++ b/test/actions/AuthorisedActionSpec.scala
@@ -16,91 +16,108 @@
 
 package actions
 
+import models.auth.DelegatedAuthRules
+import models.auth.Enrolment.{Agent, Individual, Nino, SupportingAgent}
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.SystemMaterializer
 import play.api.http.Status._
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.test.{FakeRequest, Helpers}
+import uk.gov.hmrc.auth.core.ConfidenceLevel.L250
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.authorise.Predicate
-import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
 import uk.gov.hmrc.http.HeaderCarrier
-import models.auth.Enrolment.{Agent, Individual, Nino}
 import utils.UnitTest
-import utils.mocks.MockAuthConnector
+import utils.mocks.{MockAppConfig, MockAuthConnector}
 import utils.providers.FakeRequestProvider
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 class AuthorisedActionSpec extends UnitTest
   with MockAuthConnector
+  with MockAppConfig
   with FakeRequestProvider {
 
-  private val requestWithMtditid: FakeRequest[AnyContentAsEmpty.type] = fakeRequest.withHeaders("mtditid" -> "1234567890")
+  val mtditid = "1234567890"
+  val arn = "0987654321"
+  val nino = "AA123456C"
+  private val requestWithMtditid: FakeRequest[AnyContentAsEmpty.type] = fakeRequest.withHeaders("mtditid" -> mtditid)
   private implicit val emptyHeaderCarrier: HeaderCarrier = HeaderCarrier()
   private implicit val actorSystem: ActorSystem = ActorSystem()
   private implicit val mockControllerComponents: ControllerComponents = Helpers.stubControllerComponents()
   private val defaultActionBuilder: DefaultActionBuilder = DefaultActionBuilder(mockControllerComponents.parsers.default)
   implicit val materializer: SystemMaterializer = SystemMaterializer(actorSystem)
 
-  private val underTest: AuthorisedAction = new AuthorisedAction(defaultActionBuilder, mockAuthConnector, mockControllerComponents)
+  private val underTest: AuthorisedAction = new AuthorisedAction(defaultActionBuilder, mockAuthConnector, mockControllerComponents, mockAppConfig)
+
+  lazy val block: AuthorisationRequest[AnyContent] => Future[Result] = request =>
+    Future.successful(Ok(s"mtditid: ${request.user.mtditid}${request.user.arn.fold("")(arn => " arn: " + arn)}"))
 
   ".async" should {
-    lazy val block: AuthorisationRequest[AnyContent] => Future[Result] = request =>
-      Future.successful(Ok(s"mtditid: ${request.user.mtditid}${request.user.arn.fold("")(arn => " arn: " + arn)}"))
-
     "perform the block action" when {
-      "the user is successfully verified as an agent" which {
-        val agentEnrolments: Enrolments = Enrolments(Set(
-          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, "1234567890")), "Activated"),
-          Enrolment(Agent.key, Seq(EnrolmentIdentifier(Agent.value, "0987654321")), "Activated")
-        ))
-
-        mockAuthAsAgent(agentEnrolments)
-
-        val result = await(underTest.async(block)(requestWithMtditid))
-
+      "the user is successfully verified as an Primary Agent" which {
         "should return an OK(200) status" in {
+          mockAuthAffinityGroup(AffinityGroup.Agent)
+          mockAuthAsPrimaryAgent(mtditid)(Enrolments(Set(
+            Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated"),
+            Enrolment(Agent.key, Seq(EnrolmentIdentifier(Agent.value, arn)), "Activated")
+          )))
+
+          val result = await(underTest.async(block)(requestWithMtditid))
+
           result.header.status shouldBe OK
-          await(result.body.consumeData.map(_.utf8String)) shouldBe "mtditid: 1234567890 arn: 0987654321"
+          await(result.body.consumeData.map(_.utf8String)) shouldBe s"mtditid: $mtditid arn: $arn"
+        }
+      }
+
+      "the user is successfully verified as a Secondary Agent (EMA Supporting Agent enabled)" which {
+        "should return an OK(200) status" in {
+          MockAppConfig.emaSupportingAgentsEnabled(true)
+          mockAuthAffinityGroup(AffinityGroup.Agent)
+          mockAuthReturnException(primaryAgentPredicate(mtditid), Retrievals.allEnrolments)(new InsufficientConfidenceLevel)
+          mockAuthAsSecondaryAgent(mtditid)(Enrolments(Set(
+            Enrolment(
+              key = SupportingAgent.key,
+              identifiers = Seq(EnrolmentIdentifier(Individual.value, mtditid)),
+              state = "Activated",
+              delegatedAuthRule = Some(DelegatedAuthRules.supportingAgentDelegatedAuthRule)
+            ),
+            Enrolment(Agent.key, Seq(EnrolmentIdentifier(Agent.value, arn)), "Activated")
+          )))
+
+          val result = await(underTest.async(block)(requestWithMtditid))
+
+          result.header.status shouldBe OK
+          await(result.body.consumeData.map(_.utf8String)) shouldBe s"mtditid: $mtditid arn: $arn"
         }
       }
 
       "the user is successfully verified as an individual" in {
-        val individualEnrolments: Enrolments = Enrolments(Set(
-          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, "1234567890")), "Activated"),
-          Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, "1234567890")), "Activated")
-        ))
+        mockAuthAffinityGroup(AffinityGroup.Individual)
+        mockAuthAsIndividual(Enrolments(Set(
+          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated"),
+          Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, mtditid)), "Activated")
+        )) and L250)
 
-        mockAuth(individualEnrolments)
-
-        lazy val result = await(underTest.async(block)(requestWithMtditid))
+        val result = await(underTest.async(block)(requestWithMtditid))
 
         result.header.status shouldBe OK
-        await(result.body.consumeData.map(_.utf8String)) shouldBe "mtditid: 1234567890"
+        await(result.body.consumeData.map(_.utf8String)) shouldBe s"mtditid: $mtditid"
       }
     }
 
     "return an Unauthorised" when {
       "the authorisation service returns an AuthorisationException exception" in {
-        object AuthException extends AuthorisationException("Some reason")
-
-        mockAuthReturnException(AuthException)
-
+        mockAuthReturnException(EmptyPredicate, Retrievals.affinityGroup)(InsufficientEnrolments())
         await(underTest.async(block)(requestWithMtditid)).header.status shouldBe UNAUTHORIZED
       }
-    }
 
-    "return an Unauthorised" when {
       "the authorisation service returns a NoActiveSession exception" in {
-        object NoActiveSession extends NoActiveSession("Some reason")
-
-        mockAuthReturnException(NoActiveSession)
-
+        mockAuthReturnException(EmptyPredicate, Retrievals.affinityGroup)(MissingBearerToken())
         await(underTest.async(block)(requestWithMtditid)).header.status shouldBe UNAUTHORIZED
       }
 
@@ -113,17 +130,12 @@ class AuthorisedActionSpec extends UnitTest
   ".individualAuthentication" should {
     "perform the block action" when {
       "the correct enrolment exist and nino exist" which {
-        val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-        val mtditid = "AAAAAA"
-        val enrolments = Enrolments(Set(
-          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated"),
-          Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, mtditid)), "Activated")
-        ))
-        lazy val result: Result = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-            .returning(Future.successful(enrolments and ConfidenceLevel.L250))
 
+        lazy val result: Result = {
+          mockAuthAsIndividual(Enrolments(Set(
+            Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated"),
+            Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, mtditid)), "Activated")
+          )) and ConfidenceLevel.L250)
           await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
         }
 
@@ -132,194 +144,82 @@ class AuthorisedActionSpec extends UnitTest
         }
 
         "returns a body of the mtditid" in {
-          await(result.body.consumeData.map(_.utf8String)) shouldBe mtditid
-        }
-      }
-
-      "the correct enrolment and nino exist but the request is for a different id" which {
-        val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-        val mtditid = "AAAAAA"
-        val enrolments = Enrolments(Set(
-          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, "123456")), "Activated"),
-          Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, mtditid)), "Activated")
-        ))
-        lazy val result: Result = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-            .returning(Future.successful(enrolments and ConfidenceLevel.L250))
-
-          await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
-        }
-
-        "returns an UNAUTHORIZED status" in {
-          result.header.status shouldBe UNAUTHORIZED
-        }
-      }
-
-      "the correct enrolment and nino exist but low CL" which {
-        val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-        val mtditid = "AAAAAA"
-        val enrolments = Enrolments(Set(
-          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated"),
-          Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, mtditid)), "Activated")
-        ))
-        lazy val result: Result = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-            .returning(Future.successful(enrolments and ConfidenceLevel.L50))
-
-          await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
-        }
-
-        "returns an UNAUTHORIZED status" in {
-          result.header.status shouldBe UNAUTHORIZED
-        }
-      }
-
-      "the correct enrolment exist but no nino" which {
-        val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-        val mtditid = "AAAAAA"
-        val enrolments = Enrolments(Set(Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated")))
-        lazy val result = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-            .returning(Future.successful(enrolments and ConfidenceLevel.L250))
-
-          await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
-        }
-
-        "returns an 401 status" in {
-          result.header.status shouldBe UNAUTHORIZED
-        }
-      }
-
-      "the correct nino exist but no enrolment" which {
-        val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-        val id = "AAAAAA"
-        val enrolments = Enrolments(Set(Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, id)), "Activated")))
-        lazy val result: Result = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-            .returning(Future.successful(enrolments and ConfidenceLevel.L250))
-
-          await(underTest.individualAuthentication(block, id)(requestWithMtditid, emptyHeaderCarrier))
-        }
-
-        "returns an 401 status" in {
-          result.header.status shouldBe UNAUTHORIZED
+          await(result.body.consumeData.map(_.utf8String)) shouldBe s"mtditid: $mtditid"
         }
       }
     }
 
     "return a UNAUTHORIZED" when {
-      "the correct enrolment is missing" which {
-        val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-        val mtditid = "AAAAAA"
-        val enrolments = Enrolments(Set(Enrolment("notAnIndividualOops", Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated")))
-        lazy val result: Result = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-            .returning(Future.successful(enrolments and ConfidenceLevel.L250))
+      "the correct enrolment is missing" in {
 
+        mockAuthAsIndividual(Enrolments(Set(
+          Enrolment("notAnIndividualOops", Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated")
+        )) and L250)
+
+        val result: Result =
           await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
-        }
 
-        "returns a forbidden" in {
-          result.header.status shouldBe UNAUTHORIZED
-        }
-      }
-    }
-
-    "the correct enrolment and nino exist but the request is for a different id" which {
-      val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-      val mtditid = "AAAAAA"
-      val enrolments = Enrolments(Set(
-        Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, "123456")), "Activated"),
-        Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, mtditid)), "Activated")
-      ))
-      lazy val result: Result = {
-        (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-          .returning(Future.successful(enrolments and ConfidenceLevel.L250))
-
-        await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
-      }
-
-      "returns an UNAUTHORIZED status" in {
         result.header.status shouldBe UNAUTHORIZED
       }
-    }
 
-    "the correct enrolment and nino exist but low CL" which {
-      val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-      val mtditid = "AAAAAA"
-      val enrolments = Enrolments(Set(
-        Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated"),
-        Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, mtditid)), "Activated")
-      ))
-      lazy val result: Result = {
-        (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-          .returning(Future.successful(enrolments and ConfidenceLevel.L50))
+      "the correct enrolment and nino exist but the request is for a different id" in {
 
-        await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
-      }
+        mockAuthAsIndividual(Enrolments(Set(
+          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, "123456")), "Activated"),
+          Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, mtditid)), "Activated")
+        )) and L250)
 
-      "returns an UNAUTHORIZED status" in {
+        val result: Result = await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
+
         result.header.status shouldBe UNAUTHORIZED
       }
-    }
 
-    "the correct enrolment exist but no nino" which {
-      val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-      val mtditid = "AAAAAA"
-      val enrolments = Enrolments(Set(Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated")))
-      lazy val result: Result = {
-        (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-          .returning(Future.successful(enrolments and ConfidenceLevel.L250))
+      "the correct enrolment and nino exist but low CL" in {
 
-        await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
-      }
+        mockAuthAsIndividual(Enrolments(Set(
+          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated"),
+          Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, mtditid)), "Activated")
+        )) and ConfidenceLevel.L50)
 
-      "returns an 401 status" in {
+        val result: Result = await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
+
         result.header.status shouldBe UNAUTHORIZED
       }
-    }
 
-    "the correct nino exist but no enrolment" which {
-      val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(request.user.mtditid))
-      val id = "AAAAAA"
-      val enrolments = Enrolments(Set(Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, id)), "Activated")))
-      lazy val result: Result = {
-        (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-          .expects(*, Retrievals.allEnrolments and Retrievals.confidenceLevel, *, *)
-          .returning(Future.successful(enrolments and ConfidenceLevel.L250))
+      "the correct enrolment exist but no nino" in {
 
-        await(underTest.individualAuthentication(block, id)(requestWithMtditid, emptyHeaderCarrier))
+        mockAuthAsIndividual(Enrolments(Set(
+          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated")
+        )) and ConfidenceLevel.L250)
+
+        val result: Result = await(underTest.individualAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
+
+        result.header.status shouldBe UNAUTHORIZED
       }
 
-      "returns an 401 status" in {
+      "the correct nino exist but no enrolment" in {
+
+        mockAuthAsIndividual(Enrolments(Set(
+          Enrolment(Nino.key, Seq(EnrolmentIdentifier(Nino.value, nino)), "Activated")
+        )) and ConfidenceLevel.L250)
+
+        val result: Result = await(underTest.individualAuthentication(block, nino)(requestWithMtditid, emptyHeaderCarrier))
+
         result.header.status shouldBe UNAUTHORIZED
       }
     }
   }
 
   ".agentAuthentication" should {
-    val block: AuthorisationRequest[AnyContent] => Future[Result] = request => Future.successful(Ok(s"${request.user.mtditid} ${request.user.arn.get}"))
-
     "perform the block action" when {
-      "the agent is authorised for the given user" which {
-        val enrolments = Enrolments(Set(
-          Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, "1234567890")), "Activated"),
-          Enrolment(Agent.key, Seq(EnrolmentIdentifier(Agent.value, "0987654321")), "Activated")
-        ))
-        lazy val result = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments, *, *)
-            .returning(Future.successful(enrolments))
+      "the agent is authorised for the given user (Primary Agent)" which {
 
-          await(underTest.agentAuthentication(block, "1234567890")(requestWithMtditid, emptyHeaderCarrier))
+        lazy val result = {
+          mockAuthAsPrimaryAgent(mtditid)(Enrolments(Set(
+            Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated"),
+            Enrolment(Agent.key, Seq(EnrolmentIdentifier(Agent.value, arn)), "Activated")
+          )))
+          await(underTest.agentAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
         }
 
         "has a status of OK" in {
@@ -327,47 +227,74 @@ class AuthorisedActionSpec extends UnitTest
         }
 
         "has the correct body" in {
-          await(result.body.consumeData.map(_.utf8String)) shouldBe "1234567890 0987654321"
+          await(result.body.consumeData.map(_.utf8String)) shouldBe s"mtditid: $mtditid arn: $arn"
         }
       }
-    }
 
-    "return an Unauthorised" when {
-      "the authorisation service returns an AuthorisationException exception" in {
-        object AuthException extends AuthorisationException("some-exception-reason")
+      "the agent is authorised for the given user (Secondary Agent - EMA Supporting Agent Feature enabled)" which {
 
         lazy val result = {
-          mockAuthReturnException(AuthException)
-          underTest.agentAuthentication(block, "1234567890")(requestWithMtditid, emptyHeaderCarrier)
+          MockAppConfig.emaSupportingAgentsEnabled(true)
+          mockAuthReturnException(primaryAgentPredicate(mtditid), Retrievals.allEnrolments)(InsufficientEnrolments())
+          mockAuthConnectorResponse(secondaryAgentPredicate(mtditid), Retrievals.allEnrolments)(Future.successful(
+            Enrolments(Set(
+              Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated"),
+              Enrolment(Agent.key, Seq(EnrolmentIdentifier(Agent.value, arn)), "Activated")
+            ))
+          ))
+
+          await(underTest.agentAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier))
         }
 
-        await(result).header.status shouldBe UNAUTHORIZED
+        "has a status of OK" in {
+          result.header.status shouldBe OK
+        }
+
+        "has the correct body" in {
+          await(result.body.consumeData.map(_.utf8String)) shouldBe s"mtditid: $mtditid arn: $arn"
+        }
       }
     }
 
     "return an Unauthorised" when {
+
       "the authorisation service returns a NoActiveSession exception" in {
-        object NoActiveSession extends NoActiveSession("Some reason")
 
-        lazy val result = {
-          mockAuthReturnException(NoActiveSession)
-          underTest.agentAuthentication(block, "1234567890")(requestWithMtditid, emptyHeaderCarrier)
-        }
+        mockAuthReturnException(primaryAgentPredicate(mtditid), Retrievals.allEnrolments)(BearerTokenExpired())
+
+        val result =underTest.agentAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier)
 
         await(result).header.status shouldBe UNAUTHORIZED
       }
-    }
 
-    "return a UNAUTHORIZED" when {
+      "the authorisation service returns an AuthorisationException exception (EMA Supporting Agent Disabled)" in {
+
+        MockAppConfig.emaSupportingAgentsEnabled(false)
+        mockAuthReturnException(primaryAgentPredicate(mtditid), Retrievals.allEnrolments)(InsufficientEnrolments())
+
+        val result = underTest.agentAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier)
+
+        await(result).header.status shouldBe UNAUTHORIZED
+      }
+
+      "the authorisation service returns an AuthorisationException for secondary agent check (EMA Supporting Agent Enabled)" in {
+
+        MockAppConfig.emaSupportingAgentsEnabled(true)
+        mockAuthReturnException(primaryAgentPredicate(mtditid), Retrievals.allEnrolments)(InsufficientEnrolments())
+        mockAuthReturnException(secondaryAgentPredicate(mtditid), Retrievals.allEnrolments)(InsufficientEnrolments())
+
+        val result = underTest.agentAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier)
+
+        await(result).header.status shouldBe UNAUTHORIZED
+      }
+
       "the user does not have an enrolment for the agent" in {
-        val enrolments = Enrolments(Set(Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, "1234567890")), "Activated")))
-        lazy val result = {
-          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
-            .expects(*, Retrievals.allEnrolments, *, *)
-            .returning(Future.successful(enrolments))
 
-          underTest.agentAuthentication(block, "1234567890")(requestWithMtditid, emptyHeaderCarrier)
-        }
+        mockAuthAsPrimaryAgent(mtditid)(
+          Enrolments(Set(Enrolment(Individual.key, Seq(EnrolmentIdentifier(Individual.value, mtditid)), "Activated")))
+        )
+
+        val result = underTest.agentAuthentication(block, mtditid)(requestWithMtditid, emptyHeaderCarrier)
 
         await(result).header.status shouldBe UNAUTHORIZED
       }

--- a/test/utils/AppConfigStub.scala
+++ b/test/utils/AppConfigStub.scala
@@ -16,7 +16,7 @@
 
 package utils
 
-import config.AppConfig
+import config.{AppConfig, AppConfigImpl}
 import org.scalamock.scalatest.MockFactory
 import play.api.Configuration
 
@@ -24,7 +24,7 @@ import scala.concurrent.duration.Duration
 
 class AppConfigStub extends MockFactory {
 
-  def config(environment: String = "test"): AppConfig = new AppConfig(mock[Configuration]) {
+  def config(environment: String = "test"): AppConfig = new AppConfigImpl(mock[Configuration]) {
     private val wireMockPort = 11111
 
     private lazy val authorisationToken: String = "secret"

--- a/test/utils/mocks/MockAppConfig.scala
+++ b/test/utils/mocks/MockAppConfig.scala
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package models.auth
+package utils.mocks
 
-sealed abstract class Enrolment(val key: String, val value: String)
+import config.AppConfig
+import org.scalamock.handlers.CallHandler0
+import org.scalamock.scalatest.MockFactory
 
-object Enrolment {
-  case object Individual extends Enrolment(key = "HMRC-MTD-IT", value = "MTDITID")
-  case object SupportingAgent extends Enrolment(key = "HMRC-MTD-IT-SUPP", value = "MTDITID")
-  case object Agent extends Enrolment(key = "HMRC-AS-AGENT", value = "AgentReferenceNumber")
-  case object Nino extends Enrolment(key = "HMRC-NI", value = "NINO")
-}
+trait MockAppConfig extends MockFactory {
 
-object DelegatedAuthRules {
-  val agentDelegatedAuthRule = "mtd-it-auth"
-  val supportingAgentDelegatedAuthRule = "mtd-it-auth-supp"
+  lazy val mockAppConfig: AppConfig = mock[AppConfig]
+
+  object MockAppConfig {
+
+    def emaSupportingAgentsEnabled(response: Boolean): CallHandler0[Boolean] =
+      (() => mockAppConfig.emaSupportingAgentsEnabled).expects().returns(response)
+  }
 }

--- a/test/utils/mocks/MockMongoJourneyAnswersRepository.scala
+++ b/test/utils/mocks/MockMongoJourneyAnswersRepository.scala
@@ -32,10 +32,10 @@ import scala.concurrent.ExecutionContext.Implicits.global
 trait MockMongoJourneyAnswersRepository
     extends MockFactory with CleanMongoCollectionSupport with GuiceOneAppPerSuite with OptionValues {
 
-  val mockAppConfig: AppConfig = new AppConfigStub().config()
+  val stubAppConfig: AppConfig = new AppConfigStub().config()
 
   private val instant = Instant.now.truncatedTo(ChronoUnit.MILLIS)
   private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
-  protected val repository = new MongoJourneyAnswersRepository(mongoComponent, mockAppConfig, stubClock)
+  protected val repository = new MongoJourneyAnswersRepository(mongoComponent, stubAppConfig, stubClock)
   protected val journeyStatusService: JourneyStatusService = new JourneyStatusService(repository)
 }


### PR DESCRIPTION
Notes:
- Added Feature Switch for EMA Supporting/Secondary Agent
- Added logic for authentication against the secondary agent predicate when EMA feature is enabled and Primary Agent call fails

App Config PR:
- https://github.com/hmrc/app-config-base/pull/11385