### PR TITLE
SASS-11432: Add CommonTaskList API

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -28,6 +28,7 @@ trait AppConfig {
   def ifBaseUrl: String
   def timeToLive: Int
   def ifEnvironment: String
+  def propertyFrontendUrl: String
   def authorisationTokenKey: String
   def authorisationTokenFor(apiVersion: String): String
   def baseUrl(serviceName: String): String
@@ -44,6 +45,8 @@ class AppConfigImpl @Inject() (config: Configuration) extends AppConfig {
   override lazy val appName: String = config.get[String]("appName")
   override lazy val ifBaseUrl: String = baseUrl(serviceName = "integration-framework")
   override lazy val timeToLive: Int = Duration(config.get[String]("mongodb.timeToLive")).toDays.toInt
+  override lazy val propertyFrontendUrl: String =
+    s"${config.get[String]("microservice.services.income-tax-property-frontend.url")}/update-and-submit-income-tax-return/property"
 
   override def ifEnvironment: String = config.get[String]("microservice.services.integration-framework.environment")
 

--- a/app/controllers/CommonTaskListController.scala
+++ b/app/controllers/CommonTaskListController.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import actions.AuthorisedAction
+import play.api.Logging
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import services.CommonTaskListService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class CommonTaskListController @Inject()(service: CommonTaskListService,
+                                         auth: AuthorisedAction,
+                                         cc: ControllerComponents)
+                                        (implicit ec: ExecutionContext) extends BackendController(cc) with Logging {
+
+  def getCommonTaskList(taxYear: Int, nino: String): Action[AnyContent] = auth.async { implicit request =>
+    service.get(taxYear, nino, request.user.mtditid).map { taskList =>
+      Ok(Json.toJson(taskList))
+    }
+  }
+}

--- a/app/models/common/JourneyStatus.scala
+++ b/app/models/common/JourneyStatus.scala
@@ -34,4 +34,10 @@ object JourneyStatus extends Enum[JourneyStatus] with utils.PlayJsonEnum[Journey
 
   /** The completion page has been passed with answer Yes */
   case object Completed extends JourneyStatus("completed")
+
+  /** Data has been retrieved from HMRC from IF, check data now */
+  case object CheckNow extends JourneyStatus("checkNow")
+
+  /** Page under maintenance */
+  case object UnderMaintenance extends JourneyStatus("underMaintenance")
 }

--- a/app/models/taskList/SectionTitle.scala
+++ b/app/models/taskList/SectionTitle.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.taskList
+
+import enumeratum._
+
+sealed abstract class SectionTitle(override val entryName: String) extends EnumEntry {
+  override def toString: String = entryName
+}
+
+object SectionTitle extends Enum[SectionTitle] with PlayJsonEnum[SectionTitle] {
+
+  val values: IndexedSeq[SectionTitle] = findValues
+
+  case object UkPropertyTitle extends SectionTitle("UkProperty")
+
+  case object ForeignPropertyTitle extends SectionTitle("ForeignProperty")
+
+  case object UkForeignPropertyTitle extends SectionTitle("UkForeignProperty")
+}

--- a/app/models/taskList/TaskListSection.scala
+++ b/app/models/taskList/TaskListSection.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.taskList
+
+import play.api.libs.json.{Json, OFormat}
+
+case class TaskListSection(sectionTitle: SectionTitle, taskItems: Option[Seq[TaskListSectionItem]])
+
+object TaskListSection {
+  implicit val format: OFormat[TaskListSection] = Json.format[TaskListSection]
+}

--- a/app/models/taskList/TaskListSectionItem.scala
+++ b/app/models/taskList/TaskListSectionItem.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.taskList
+
+import models.common.JourneyStatus
+import play.api.libs.json.{Json, OFormat}
+
+case class TaskListSectionItem(title: TaskTitle, status: JourneyStatus, href: Option[String])
+
+object TaskListSectionItem {
+  implicit val format: OFormat[TaskListSectionItem] = Json.format[TaskListSectionItem]
+}

--- a/app/models/taskList/TaskTitle.scala
+++ b/app/models/taskList/TaskTitle.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.taskList
+
+import enumeratum._
+
+sealed abstract class TaskTitle(override val entryName: String) extends EnumEntry {
+  override def toString: String = entryName
+}
+
+object TaskTitle extends Enum[TaskTitle] with PlayJsonEnum[TaskTitle] {
+
+  val values: IndexedSeq[TaskTitle] = findValues
+
+  // UkProperty
+  case object UkProperty extends TaskTitle("UkPropertyTitle")
+
+  // ForeignProperty
+  case object ForeignProperty extends TaskTitle("ForeignPropertyTitle")
+
+  // UkForeignProperty
+  case object UkForeignProperty extends TaskTitle("UkForeignPropertyTitle")
+}

--- a/app/repositories/MongoJourneyAnswersRepository.scala
+++ b/app/repositories/MongoJourneyAnswersRepository.scala
@@ -17,7 +17,7 @@
 package repositories
 
 import config.AppConfig
-import models.common.{JourneyContext, JourneyStatus}
+import models.common.{JourneyContext, JourneyStatus, Mtditid, TaxYear}
 import models.domain.JourneyAnswers
 import org.mongodb.scala._
 import org.mongodb.scala.bson._
@@ -119,6 +119,16 @@ class MongoJourneyAnswersRepository @Inject() (mongo: MongoComponent, appConfig:
     collection.find(filter).toFuture()
   }
 
+  def fetchAllJourneysUserTaxYear(taxYear: Int, mtditid: String): Future[Seq[JourneyAnswers]] = {
+    val filter: Bson = Filters
+      .and(
+        Filters.equal("taxYear", taxYear),
+        Filters.equal("mtditid", mtditid)
+      )
+
+    collection.find(filter).toFuture()
+  }
+
   def fetchAllJourneys(ctx: JourneyContext): Future[Seq[JourneyAnswers]] = {
     val filter: Bson = Filters
       .and(
@@ -168,7 +178,8 @@ class MongoJourneyAnswersRepository @Inject() (mongo: MongoComponent, appConfig:
     val now = Instant.now(clock)
     Updates.combine(
       Updates.set("status", status.entryName),
-      Updates.set("updatedAt", now)
+      Updates.set("updatedAt", now),
+      Updates.setOnInsert("createdAt", now)
     )
   }
 

--- a/app/services/CommonTaskListService.scala
+++ b/app/services/CommonTaskListService.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import config.AppConfig
+import models.common.{JourneyName, JourneyStatus}
+import models.domain.JourneyAnswers
+import models.errors.DataNotFoundError
+import models.prePopulation.PrePopulationResponse
+import models.taskList._
+import play.api.Logging
+import repositories.MongoJourneyAnswersRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class CommonTaskListService @Inject()(appConfig: AppConfig,
+                                      service: BusinessDetailsService,
+                                      repository: MongoJourneyAnswersRepository) extends Logging {
+
+  def get(taxYear: Int, nino: String, mtdItId: String)
+         (implicit ec: ExecutionContext,hc: HeaderCarrier): Future[Seq[TaskListSection]] = {
+
+    val ukPropertyUrl: String = s"${appConfig.propertyFrontendUrl}/$taxYear/uk-property/about/start"
+    val foreignPropertyUrl: String = s"${appConfig.propertyFrontendUrl}/$taxYear/foreign-property/about/start"
+    val ukForeignPropertyUrl: String = s"${appConfig.propertyFrontendUrl}/$taxYear/uk-foreign-property/about/start"
+
+    def result(): Future[Seq[TaskListSection]] = {
+      for {
+        allBusinessDataOpt <- service.getBusinessDetails(nino).map {
+          case Right(businessDetails)  => PrePopulationResponse.fromData(businessDetails)
+          case Left(DataNotFoundError) => PrePopulationResponse.noPrePop
+          case Left(err)               =>
+            logger.warn(s"[CommonTaskListService][result] - An error occurred while checking the user's Property data for pre-pop $err")
+            PrePopulationResponse.noPrePop
+        }
+        allJourneys <- repository.fetchAllJourneysUserTaxYear(taxYear, mtdItId)
+        ukJourneyAnswersOpt = allJourneys.find(_.journey == JourneyName.About)
+        foreignJourneyAnswersOpt = allJourneys.find(_.journey == JourneyName.ForeignPropertySelectCountry)
+        ukAndForeignJourneyAnswersOpt = allJourneys.find(_.journey == JourneyName.UkAndForeignPropertyAbout)
+        taskList = toTaskList(allBusinessDataOpt, ukJourneyAnswersOpt, foreignJourneyAnswersOpt, ukAndForeignJourneyAnswersOpt)
+      } yield taskList
+    }
+
+    def toTaskList(prePopulationResponse: PrePopulationResponse,
+                   ukPropertyJourneyAnswersOpt: Option[JourneyAnswers],
+                   foreignPropertyJourneyAnswersOpt: Option[JourneyAnswers],
+                   ukAndForeignPropertyJourneyAnswersOpt: Option[JourneyAnswers]): Seq[TaskListSection] = {
+      val ukPropertyTask: Option[Seq[TaskListSectionItem]] = getPropertyTasks(
+        ifPropertyExists = prePopulationResponse.hasUkPropertyPrePop,
+        taskTitle = TaskTitle.UkProperty,
+        url = ukPropertyUrl,
+        journeyAnswers = ukPropertyJourneyAnswersOpt
+      )
+      val foreignPropertyTask: Option[Seq[TaskListSectionItem]] = getPropertyTasks(
+        ifPropertyExists = prePopulationResponse.hasForeignPropertyPrePop,
+        taskTitle = TaskTitle.ForeignProperty,
+        url = foreignPropertyUrl,
+        journeyAnswers = foreignPropertyJourneyAnswersOpt
+      )
+      val ukForeignPropertyTask: Option[Seq[TaskListSectionItem]] = getPropertyTasks(
+        ifPropertyExists = prePopulationResponse.hasUkPropertyPrePop && prePopulationResponse.hasForeignPropertyPrePop,
+        taskTitle = TaskTitle.UkForeignProperty,
+        url = ukForeignPropertyUrl,
+        journeyAnswers = ukAndForeignPropertyJourneyAnswersOpt
+      )
+      Seq(
+        TaskListSection(SectionTitle.UkPropertyTitle, ukPropertyTask),
+        TaskListSection(SectionTitle.ForeignPropertyTitle, foreignPropertyTask),
+        TaskListSection(SectionTitle.UkForeignPropertyTitle, ukForeignPropertyTask)
+      )
+    }
+
+    result()
+  }
+
+  private def getPropertyTasks(ifPropertyExists: Boolean,
+                                   taskTitle: TaskTitle,
+                                   url: String,
+                                   journeyAnswers: Option[JourneyAnswers]): Option[Seq[TaskListSectionItem]] = {
+    val loggingTitle = taskTitle.entryName.replace("Title","")
+    (ifPropertyExists, journeyAnswers) match {
+      case (_, Some(journeyAnswers)) =>
+        logger.info(s"[CommonTaskListService][getPropertyTasks] - $loggingTitle - User has journey answers, setting status to: ${journeyAnswers.status}")
+        Some(Seq(TaskListSectionItem(taskTitle, journeyAnswers.status, Some(url))))
+      case (true, _) =>
+        logger.info(s"[CommonTaskListService][getPropertyTasks] - $loggingTitle - User has no journey answers but does have PrePopData, setting status to ${JourneyStatus.CheckNow}")
+        Some(Seq(TaskListSectionItem(taskTitle, JourneyStatus.CheckNow, Some(url))))
+      case (_, _) =>
+        logger.info(s"[CommonTaskListService][getPropertyTasks] - $loggingTitle - User has no journey or PrePopData, returning None")
+        None
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val coverageSettings: Seq[Setting[?]] = {
 
   Seq(
     ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
-    ScoverageKeys.coverageMinimumStmtTotal := 80,
+    ScoverageKeys.coverageMinimumStmtTotal := 83,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -17,5 +17,8 @@ PUT           /property/completed-section/:incomeSourceId/:journey/:taxYear     
 
 PUT           /property/completed-section/:incomeSourceId/:journey/:taxYear/:countryCode        controllers.PropertyController.setForeignStatus(taxYear: TaxYear, incomeSourceId: IncomeSourceId, journey: String, countryCode: String)
 
+# Retrieve Tasklist
+GET           /:taxYear/tasks/:nino                                                             controllers.CommonTaskListController.getCommonTaskList(taxYear: Int, nino: String)
+
 # Retrieve PrePopulation Data
 GET           /property/pre-population/:nino                                                    controllers.PrePopulationController.get(nino: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,10 +59,12 @@ mongodb {
 
 microservice {
   services {
+
     auth {
       host = localhost
       port = 8500
     }
+
     integration-framework {
       host = "localhost"
       environment = "test"
@@ -95,6 +97,10 @@ microservice {
       }
       port = 9303
       #This is the port for the income-tax-submission-stub
+    }
+
+    income-tax-property-frontend {
+      url = "http://localhost:19161"
     }
   }
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.11.0"
+  private val bootstrapVersion = "9.12.0"
   private val hmrcMongoVersion = "2.6.0"
   private val monocleVersion = "3.3.0"
   val jacksonAndPlayExclusions: Seq[ExclusionRule] = Seq(
@@ -17,7 +17,7 @@ object AppDependencies {
     "uk.gov.hmrc"                  %% "bootstrap-backend-play-30" % bootstrapVersion,
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-30"        % hmrcMongoVersion,
     "org.typelevel"                %% "cats-core"                 % "2.13.0",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"      % "2.18.3",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"      % "2.19.0",
     "com.beachape"                 %% "enumeratum"                % "1.7.6",
     "com.beachape"                 %% "enumeratum-play-json"      % "1.8.2" excludeAll (jacksonAndPlayExclusions *),
     "dev.optics"                   %% "monocle-core"              % monocleVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -18,7 +18,7 @@ object AppDependencies {
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-30"        % hmrcMongoVersion,
     "org.typelevel"                %% "cats-core"                 % "2.13.0",
     "com.fasterxml.jackson.module" %% "jackson-module-scala"      % "2.18.3",
-    "com.beachape"                 %% "enumeratum"                % "1.7.5",
+    "com.beachape"                 %% "enumeratum"                % "1.7.6",
     "com.beachape"                 %% "enumeratum-play-json"      % "1.8.2" excludeAll (jacksonAndPlayExclusions *),
     "dev.optics"                   %% "monocle-core"              % monocleVersion,
     "dev.optics"                   %% "monocle-macro"             % monocleVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.6")
+addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.7")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.3.1")
 addSbtPlugin("org.scalastyle"   %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"          % "2.5.4")

--- a/test/controllers/CommonTaskListControllerSpec.scala
+++ b/test/controllers/CommonTaskListControllerSpec.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import models.common.JourneyStatus
+import models.taskList.{SectionTitle, TaskListSection, TaskListSectionItem, TaskTitle}
+import org.scalamock.handlers.CallHandler5
+import play.api.http.Status.OK
+import play.api.libs.json.{JsValue, Json}
+import play.api.test.Helpers.{contentAsJson, status}
+import services.CommonTaskListService
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.mocks.MockAuthorisedAction
+import utils.providers.FakeRequestProvider
+import utils.{ControllerUnitTest, TaxYearUtils}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CommonTaskListControllerSpec extends ControllerUnitTest with MockAuthorisedAction with FakeRequestProvider {
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+  val nino: String = "123456789"
+  val taxYear: Int = TaxYearUtils.taxYear
+
+  val commonTaskListService: CommonTaskListService = mock[CommonTaskListService]
+  val controller = new CommonTaskListController(commonTaskListService, mockAuthorisedAction, cc)
+
+  def taskListSection(title: SectionTitle, section: Option[Seq[TaskListSectionItem]]): TaskListSection = TaskListSection(title, section)
+
+  val ukItem: Option[Seq[TaskListSectionItem]] = Some(Seq(TaskListSectionItem(TaskTitle.UkProperty, JourneyStatus.Completed, Some("TEST"))))
+  val foreignItem: Option[Seq[TaskListSectionItem]] = Some(Seq(TaskListSectionItem(TaskTitle.ForeignProperty, JourneyStatus.Completed, Some("TEST"))))
+  val ukForeignItem: Option[Seq[TaskListSectionItem]] = Some(Seq(TaskListSectionItem(TaskTitle.UkForeignProperty, JourneyStatus.Completed, Some("TEST"))))
+
+  val returnJsonNone: JsValue = Json.parse(
+    """
+      |[
+      |  {
+      |    "sectionTitle": "UkProperty"
+      |  },
+      |  {
+      |    "sectionTitle": "ForeignProperty"
+      |  },
+      |  {
+      |    "sectionTitle": "UkForeignProperty"
+      |  }
+      |]
+      |""".stripMargin
+  )
+
+  val returnJsonSome: JsValue = Json.parse(
+    """
+      |[
+      |  {
+      |    "sectionTitle": "UkProperty",
+      |    "taskItems": [
+      |      {
+      |        "title": "UkPropertyTitle",
+      |        "status": "completed",
+      |        "href": "TEST"
+      |      }
+      |    ]
+      |  },
+      |  {
+      |    "sectionTitle": "ForeignProperty",
+      |    "taskItems": [
+      |      {
+      |        "title": "ForeignPropertyTitle",
+      |        "status": "completed",
+      |        "href": "TEST"
+      |      }
+      |    ]
+      |  },
+      |  {
+      |    "sectionTitle": "UkForeignProperty",
+      |    "taskItems": [
+      |      {
+      |        "title": "UkForeignPropertyTitle",
+      |        "status": "completed",
+      |        "href": "TEST"
+      |      }
+      |    ]
+      |  }
+      |]
+      |""".stripMargin
+  )
+
+  def mockStateBenefitsService(taskListSection: Seq[TaskListSection]): CallHandler5[Int, String, String, ExecutionContext, HeaderCarrier, Future[Seq[TaskListSection]]] = {
+    (commonTaskListService.get(_: Int, _: String, _: String)(_: ExecutionContext, _: HeaderCarrier))
+      .expects(*, *, *, *, *)
+      .returning(Future.successful(taskListSection))
+  }
+
+  ".getCommonTaskList" should {
+    "return a task list section model for None returns" in {
+      val result = {
+        mockAuthorisation()
+        mockStateBenefitsService(Seq(
+          taskListSection(SectionTitle.UkPropertyTitle, None),
+          taskListSection(SectionTitle.ForeignPropertyTitle, None),
+          taskListSection(SectionTitle.UkForeignPropertyTitle, None)
+        ))
+        controller.getCommonTaskList(taxYear, nino)(fakeRequest)
+      }
+
+      status(result) shouldBe OK
+      contentAsJson(result) shouldBe returnJsonNone
+    }
+
+    "return a task list section model for Some() returns" in {
+      val result = {
+        mockAuthorisation()
+        mockStateBenefitsService(Seq(
+          taskListSection(SectionTitle.UkPropertyTitle, ukItem),
+          taskListSection(SectionTitle.ForeignPropertyTitle, foreignItem),
+          taskListSection(SectionTitle.UkForeignPropertyTitle, ukForeignItem)
+        ))
+        controller.getCommonTaskList(taxYear, nino)(fakeRequest)
+      }
+
+      status(result) shouldBe OK
+      contentAsJson(result) shouldBe returnJsonSome
+    }
+  }
+}

--- a/test/controllers/CommonTaskListControllerSpec.scala
+++ b/test/controllers/CommonTaskListControllerSpec.scala
@@ -97,7 +97,7 @@ class CommonTaskListControllerSpec extends ControllerUnitTest with MockAuthorise
       |""".stripMargin
   )
 
-  def mockStateBenefitsService(taskListSection: Seq[TaskListSection]): CallHandler5[Int, String, String, ExecutionContext, HeaderCarrier, Future[Seq[TaskListSection]]] = {
+  def mockPropertyService(taskListSection: Seq[TaskListSection]): CallHandler5[Int, String, String, ExecutionContext, HeaderCarrier, Future[Seq[TaskListSection]]] = {
     (commonTaskListService.get(_: Int, _: String, _: String)(_: ExecutionContext, _: HeaderCarrier))
       .expects(*, *, *, *, *)
       .returning(Future.successful(taskListSection))
@@ -107,7 +107,7 @@ class CommonTaskListControllerSpec extends ControllerUnitTest with MockAuthorise
     "return a task list section model for None returns" in {
       val result = {
         mockAuthorisation()
-        mockStateBenefitsService(Seq(
+        mockPropertyService(Seq(
           taskListSection(SectionTitle.UkPropertyTitle, None),
           taskListSection(SectionTitle.ForeignPropertyTitle, None),
           taskListSection(SectionTitle.UkForeignPropertyTitle, None)
@@ -122,7 +122,7 @@ class CommonTaskListControllerSpec extends ControllerUnitTest with MockAuthorise
     "return a task list section model for Some() returns" in {
       val result = {
         mockAuthorisation()
-        mockStateBenefitsService(Seq(
+        mockPropertyService(Seq(
           taskListSection(SectionTitle.UkPropertyTitle, ukItem),
           taskListSection(SectionTitle.ForeignPropertyTitle, foreignItem),
           taskListSection(SectionTitle.UkForeignPropertyTitle, ukForeignItem)

--- a/test/models/common/JourneyStatusSpec.scala
+++ b/test/models/common/JourneyStatusSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.common
+
+import models.common.JourneyStatus._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.libs.json.{JsPath, JsSuccess, Json}
+
+class JourneyStatusSpec extends AnyFreeSpec with Matchers {
+
+  "Completed" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(Completed)
+
+      underTest.toString() mustBe s"\"$Completed\""
+      underTest.validate[JourneyStatus] mustBe JsSuccess(Completed, JsPath())
+    }
+  }
+
+  "InProgress" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(InProgress)
+
+      underTest.toString() mustBe s"\"$InProgress\""
+      underTest.validate[JourneyStatus] mustBe JsSuccess(InProgress, JsPath())
+    }
+  }
+
+  "CheckNow" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(CheckNow)
+
+      underTest.toString() mustBe s"\"$CheckNow\""
+      underTest.validate[JourneyStatus] mustBe JsSuccess(CheckNow, JsPath())
+    }
+  }
+
+  "NotStarted" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(NotStarted)
+
+      underTest.toString() mustBe s"\"$NotStarted\""
+      underTest.validate[JourneyStatus] mustBe JsSuccess(NotStarted, JsPath())
+    }
+  }
+
+  "UnderMaintenance" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(UnderMaintenance)
+
+      underTest.toString() mustBe s"\"$UnderMaintenance\""
+      underTest.validate[JourneyStatus] mustBe JsSuccess(UnderMaintenance, JsPath())
+    }
+  }
+
+}

--- a/test/models/common/JourneyStatusSpec.scala
+++ b/test/models/common/JourneyStatusSpec.scala
@@ -19,58 +19,35 @@ package models.common
 import models.common.JourneyStatus._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import play.api.libs.json.{JsPath, JsSuccess, Json}
+import play.api.libs.json.{JsPath, JsString, JsSuccess, Json}
 
 class JourneyStatusSpec extends AnyFreeSpec with Matchers {
 
-  "Completed" - {
+  "JourneyStatus" - {
+    "must contain the correct values" in {
+      JourneyStatus.values mustEqual IndexedSeq[JourneyStatus](
+        NotStarted,
+        InProgress,
+        Completed,
+        CheckNow,
+        UnderMaintenance
+      )
+    }
 
-    "must parse to and from json" in {
-      val underTest = Json.toJson(Completed)
+    "must parse each element as JSON successfully" - {
 
-      underTest.toString() mustBe s"\"$Completed\""
-      underTest.validate[JourneyStatus] mustBe JsSuccess(Completed, JsPath())
+      JourneyStatus.values.foreach { journeyStatus =>
+        s"for ${journeyStatus.toString}" - {
+
+          "serialize to JSON" in {
+            Json.toJson(journeyStatus) mustBe JsString(journeyStatus.toString)
+          }
+
+          "deserialize from JSON" in {
+            JsString(journeyStatus.toString).validate[JourneyStatus] mustBe JsSuccess(journeyStatus, JsPath())
+          }
+        }
+      }
     }
   }
-
-  "InProgress" - {
-
-    "must parse to and from json" in {
-      val underTest = Json.toJson(InProgress)
-
-      underTest.toString() mustBe s"\"$InProgress\""
-      underTest.validate[JourneyStatus] mustBe JsSuccess(InProgress, JsPath())
-    }
-  }
-
-  "CheckNow" - {
-
-    "must parse to and from json" in {
-      val underTest = Json.toJson(CheckNow)
-
-      underTest.toString() mustBe s"\"$CheckNow\""
-      underTest.validate[JourneyStatus] mustBe JsSuccess(CheckNow, JsPath())
-    }
-  }
-
-  "NotStarted" - {
-
-    "must parse to and from json" in {
-      val underTest = Json.toJson(NotStarted)
-
-      underTest.toString() mustBe s"\"$NotStarted\""
-      underTest.validate[JourneyStatus] mustBe JsSuccess(NotStarted, JsPath())
-    }
-  }
-
-  "UnderMaintenance" - {
-
-    "must parse to and from json" in {
-      val underTest = Json.toJson(UnderMaintenance)
-
-      underTest.toString() mustBe s"\"$UnderMaintenance\""
-      underTest.validate[JourneyStatus] mustBe JsSuccess(UnderMaintenance, JsPath())
-    }
-  }
-
 }

--- a/test/models/taskList/SectionTitleSpec.scala
+++ b/test/models/taskList/SectionTitleSpec.scala
@@ -19,37 +19,33 @@ package models.taskList
 import models.taskList.SectionTitle._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import play.api.libs.json.{JsPath, JsSuccess, Json}
+import play.api.libs.json.{JsPath, JsString, JsSuccess, Json}
 
 class SectionTitleSpec extends AnyFreeSpec with Matchers {
 
-  "UkPropertyTitle" - {
-
-    "must parse to and from json" in {
-      val underTest = Json.toJson(UkPropertyTitle)
-
-      underTest.toString() mustBe s"\"$UkPropertyTitle\""
-      underTest.validate[SectionTitle] mustBe JsSuccess(UkPropertyTitle, JsPath())
+  "SectionTitle" - {
+    "must contain the correct values" in {
+      SectionTitle.values mustEqual Seq[SectionTitle](
+        UkPropertyTitle,
+        ForeignPropertyTitle,
+        UkForeignPropertyTitle
+      )
     }
-  }
 
-  "ForeignPropertyTitle" - {
+    "must parse each element as JSON successfully" - {
 
-    "must parse to and from json" in {
-      val underTest = Json.toJson(ForeignPropertyTitle)
+      SectionTitle.values.foreach { sectionTitle =>
+        s"for ${sectionTitle.toString}" - {
 
-      underTest.toString() mustBe s"\"$ForeignPropertyTitle\""
-      underTest.validate[SectionTitle] mustBe JsSuccess(ForeignPropertyTitle, JsPath())
-    }
-  }
+          "serialize to JSON" in {
+            Json.toJson(sectionTitle) mustBe JsString(sectionTitle.toString)
+          }
 
-  "UkForeignPropertyTitle" - {
-
-    "must parse to and from json" in {
-      val underTest = Json.toJson(UkForeignPropertyTitle)
-
-      underTest.toString() mustBe s"\"$UkForeignPropertyTitle\""
-      underTest.validate[SectionTitle] mustBe JsSuccess(UkForeignPropertyTitle, JsPath())
+          "deserialize from JSON" in {
+            JsString(sectionTitle.toString).validate[SectionTitle] mustBe JsSuccess(sectionTitle, JsPath())
+          }
+        }
+      }
     }
   }
 }

--- a/test/models/taskList/SectionTitleSpec.scala
+++ b/test/models/taskList/SectionTitleSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.taskList
+
+import models.taskList.SectionTitle._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.libs.json.{JsPath, JsSuccess, Json}
+
+class SectionTitleSpec extends AnyFreeSpec with Matchers {
+
+  "UkPropertyTitle" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(UkPropertyTitle)
+
+      underTest.toString() mustBe s"\"$UkPropertyTitle\""
+      underTest.validate[SectionTitle] mustBe JsSuccess(UkPropertyTitle, JsPath())
+    }
+  }
+
+  "ForeignPropertyTitle" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(ForeignPropertyTitle)
+
+      underTest.toString() mustBe s"\"$ForeignPropertyTitle\""
+      underTest.validate[SectionTitle] mustBe JsSuccess(ForeignPropertyTitle, JsPath())
+    }
+  }
+
+  "UkForeignPropertyTitle" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(UkForeignPropertyTitle)
+
+      underTest.toString() mustBe s"\"$UkForeignPropertyTitle\""
+      underTest.validate[SectionTitle] mustBe JsSuccess(UkForeignPropertyTitle, JsPath())
+    }
+  }
+}

--- a/test/models/taskList/TaskTitleSpec.scala
+++ b/test/models/taskList/TaskTitleSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.taskList
+
+import models.taskList.TaskTitle._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.libs.json.{JsPath, JsSuccess, JsValue, Json}
+
+class TaskTitleSpec extends AnyFreeSpec with Matchers {
+
+  "TaskTitle" - {
+
+    "must contain the correct values" in {
+      TaskTitle.values mustEqual Seq[TaskTitle](
+        UkProperty,
+        ForeignProperty,
+        UkForeignProperty
+      )
+    }
+
+    "must parse each element to jsValue successfully" in {
+      val underTest: Seq[JsValue] = TaskTitle.values.map(x => Json.toJson(x))
+      underTest.isInstanceOf[Seq[JsValue]] mustBe true
+    }
+  }
+
+  "UkProperty" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(UkProperty)
+
+      underTest.toString() mustBe s"\"$UkProperty\""
+      underTest.validate[TaskTitle] mustBe JsSuccess(UkProperty, JsPath())
+    }
+  }
+
+  "ForeignProperty" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(ForeignProperty)
+
+      underTest.toString() mustBe s"\"$ForeignProperty\""
+      underTest.validate[TaskTitle] mustBe JsSuccess(ForeignProperty, JsPath())
+    }
+  }
+
+  "UkForeignProperty" - {
+
+    "must parse to and from json" in {
+      val underTest = Json.toJson(UkForeignProperty)
+
+      underTest.toString() mustBe s"\"$UkForeignProperty\""
+      underTest.validate[TaskTitle] mustBe JsSuccess(UkForeignProperty, JsPath())
+    }
+  }
+}

--- a/test/models/taskList/TaskTitleSpec.scala
+++ b/test/models/taskList/TaskTitleSpec.scala
@@ -19,12 +19,11 @@ package models.taskList
 import models.taskList.TaskTitle._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import play.api.libs.json.{JsPath, JsSuccess, JsValue, Json}
+import play.api.libs.json.{JsPath, JsString, JsSuccess, Json}
 
 class TaskTitleSpec extends AnyFreeSpec with Matchers {
 
   "TaskTitle" - {
-
     "must contain the correct values" in {
       TaskTitle.values mustEqual Seq[TaskTitle](
         UkProperty,
@@ -33,39 +32,20 @@ class TaskTitleSpec extends AnyFreeSpec with Matchers {
       )
     }
 
-    "must parse each element to jsValue successfully" in {
-      val underTest: Seq[JsValue] = TaskTitle.values.map(x => Json.toJson(x))
-      underTest.isInstanceOf[Seq[JsValue]] mustBe true
-    }
-  }
+    "must parse each element as JSON successfully" - {
 
-  "UkProperty" - {
+      TaskTitle.values.foreach { taskTitle =>
+        s"for ${taskTitle.toString}" - {
 
-    "must parse to and from json" in {
-      val underTest = Json.toJson(UkProperty)
+          "serialize to JSON" in {
+            Json.toJson(taskTitle) mustBe JsString(taskTitle.toString)
+          }
 
-      underTest.toString() mustBe s"\"$UkProperty\""
-      underTest.validate[TaskTitle] mustBe JsSuccess(UkProperty, JsPath())
-    }
-  }
-
-  "ForeignProperty" - {
-
-    "must parse to and from json" in {
-      val underTest = Json.toJson(ForeignProperty)
-
-      underTest.toString() mustBe s"\"$ForeignProperty\""
-      underTest.validate[TaskTitle] mustBe JsSuccess(ForeignProperty, JsPath())
-    }
-  }
-
-  "UkForeignProperty" - {
-
-    "must parse to and from json" in {
-      val underTest = Json.toJson(UkForeignProperty)
-
-      underTest.toString() mustBe s"\"$UkForeignProperty\""
-      underTest.validate[TaskTitle] mustBe JsSuccess(UkForeignProperty, JsPath())
+          "deserialize from JSON" in {
+            JsString(taskTitle.toString).validate[TaskTitle] mustBe JsSuccess(taskTitle, JsPath())
+          }
+        }
+      }
     }
   }
 }

--- a/test/services/CommonTaskListServiceSpec.scala
+++ b/test/services/CommonTaskListServiceSpec.scala
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import models.common._
+import models.domain.JourneyAnswers
+import models.errors.{ApiServiceError, DataNotFoundError}
+import models.taskList._
+import models.{BusinessDetailsResponse, PropertyDetails}
+import org.mongodb.scala.MongoCollection
+import org.mongodb.scala.model.Filters
+import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.libs.json.JsObject
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.UnitTest
+import utils.mocks.{MockBusinessDetailsService, MockMongoJourneyAnswersRepository}
+import utils.providers.AppConfigStubProvider
+
+import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
+
+class CommonTaskListServiceSpec extends UnitTest
+  with MockFactory
+  with AppConfigStubProvider
+  with MockBusinessDetailsService
+  with MockMongoJourneyAnswersRepository
+  with BeforeAndAfterEach {
+
+  private trait Test {
+    implicit val ec: ExecutionContext = ExecutionContext.global
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    val service: CommonTaskListService = new CommonTaskListService(
+      appConfig = appConfigStub,
+      service = mockIntegrationFrameworkService,
+      repository = repository
+    )
+
+    val nino: String = "12345678"
+    val taxYear: Int = 2025
+    val mtdItId = "12345"
+
+    val someProperty: Seq[PropertyDetails] = List(
+      PropertyDetails(Some("uk-property"), None, None, "XYIS00000451267"),
+      PropertyDetails(Some("foreign-property"), None, None, "XYIS00000451268")
+    )
+    val someUkProperty: Seq[PropertyDetails] = List(
+      PropertyDetails(Some("uk-property"), None, None, "XYIS00000451267")
+    )
+    val someForeignProperty: Seq[PropertyDetails] = List(
+      PropertyDetails(Some("foreign-property"), None, None, "XYIS00000451268")
+    )
+
+    def journeyResponse(incomeSourceId: IncomeSourceId, journeyName: JourneyName, status: JourneyStatus, mtditid: String = mtdItId, taxyear: Int = taxYear): JourneyAnswers = {
+      JourneyAnswers(mtditid = Mtditid(mtditid),
+        incomeSourceId = incomeSourceId,
+        taxYear = TaxYear(taxyear),
+        journey = journeyName,
+        countryCode = None,
+        status = status,
+        data = JsObject.empty,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now()
+      )
+    }
+
+    def removeAll(collection: MongoCollection[_]): Future[Unit] =
+      collection
+        .deleteMany(Filters.empty())
+        .toFuture()
+        .map(_ => ())
+
+    def testOnlyAdd(journeyAnswers: JourneyAnswers): Future[Unit] = {
+      repository.collection.insertOne(journeyAnswers)
+        .toFuture()
+        .map(_ => ())
+    }
+  }
+
+  val emptyTaskSections: List[TaskListSection] = List(
+    TaskListSection(sectionTitle = SectionTitle.UkPropertyTitle, taskItems = None),
+    TaskListSection(sectionTitle = SectionTitle.ForeignPropertyTitle, taskItems = None),
+    TaskListSection(sectionTitle = SectionTitle.UkForeignPropertyTitle, taskItems = None)
+  )
+
+  val ukUrl = "http://localhost:TEST/update-and-submit-income-tax-return/property/2025/uk-property/about/start"
+  val foreignUrl = "http://localhost:TEST/update-and-submit-income-tax-return/property/2025/foreign-property/about/start"
+  val ukForeignUrl = s"http://localhost:TEST/update-and-submit-income-tax-return/property/2025/uk-foreign-property/about/start"
+
+  def taskSections(status: JourneyStatus): List[TaskListSection] = List(
+    TaskListSection(
+      sectionTitle = SectionTitle.UkPropertyTitle,
+      taskItems = Some(List(
+        TaskListSectionItem(
+          title = TaskTitle.UkProperty,
+          status = status,
+          href = Some(ukUrl)
+        )
+      ))
+    ),
+    TaskListSection(
+      sectionTitle = SectionTitle.ForeignPropertyTitle,
+      taskItems = Some(List(
+        TaskListSectionItem(
+          title = TaskTitle.ForeignProperty,
+          status = status,
+          href = Some(foreignUrl)
+        )
+      ))
+    ),
+    TaskListSection(
+      sectionTitle = SectionTitle.UkForeignPropertyTitle,
+      taskItems = Some(List(
+        TaskListSectionItem(
+          title = TaskTitle.UkForeignProperty,
+          status = status,
+          href = Some(ukForeignUrl)
+        )
+      ))
+    )
+  )
+
+  val mixedTaskSections: List[TaskListSection] = List(
+    TaskListSection(
+      sectionTitle = SectionTitle.UkPropertyTitle,
+      taskItems = Some(List(
+        TaskListSectionItem(
+          title = TaskTitle.UkProperty,
+          status = JourneyStatus.Completed,
+          href = Some(ukUrl)
+        )
+      ))
+    ),
+    TaskListSection(
+      sectionTitle = SectionTitle.ForeignPropertyTitle,
+      taskItems = Some(List(
+        TaskListSectionItem(
+          title = TaskTitle.ForeignProperty,
+          status = JourneyStatus.CheckNow,
+          href = Some(foreignUrl)
+        )
+      ))
+    ),
+    TaskListSection(
+      sectionTitle = SectionTitle.UkForeignPropertyTitle,
+      taskItems = Some(List(
+        TaskListSectionItem(
+          title = TaskTitle.UkForeignProperty,
+          status = JourneyStatus.CheckNow,
+          href = Some(ukForeignUrl)
+        )
+      ))
+    )
+  )
+
+  def ukTaskSections(status: JourneyStatus): List[TaskListSection] = List(
+    TaskListSection(
+      sectionTitle = SectionTitle.UkPropertyTitle,
+      taskItems = Some(List(
+        TaskListSectionItem(
+          title = TaskTitle.UkProperty,
+          status = status,
+          href = Some(ukUrl)
+        )
+      ))
+    ),
+    TaskListSection(sectionTitle = SectionTitle.ForeignPropertyTitle, taskItems = None),
+    TaskListSection(sectionTitle = SectionTitle.UkForeignPropertyTitle, taskItems = None),
+  )
+
+  def foreignTaskSections(status: JourneyStatus): List[TaskListSection] = List(
+    TaskListSection(sectionTitle = SectionTitle.UkPropertyTitle, taskItems = None),
+    TaskListSection(
+      sectionTitle = SectionTitle.ForeignPropertyTitle,
+      taskItems = Some(List(
+        TaskListSectionItem(
+          title = TaskTitle.ForeignProperty,
+          status = status,
+          href = Some(foreignUrl)
+        )
+      ))
+    ),
+    TaskListSection(sectionTitle = SectionTitle.UkForeignPropertyTitle, taskItems = None)
+  )
+
+  "CommonTaskListService" when {
+    "an error occurs while retrieving benefits data from IF" should {
+      "return an empty task list when IF returns an API error" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Left(ApiServiceError(500)))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) mustBe emptyTaskSections
+      }
+
+      "handle appropriately when an exception occurs" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetailsException(nino, new RuntimeException("Dummy Exception"))
+
+        await(removeAll(repository.collection))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        assertThrows[RuntimeException](await(underTest))
+      }
+    }
+
+    "the call to IF for benefits data returns a successful, but empty, response" should {
+      "return an empty task list if journeyAnswers also empty" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Left(DataNotFoundError))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe emptyTaskSections
+      }
+    }
+
+    "Property repository contains no journeyAnswers" should {
+      "return an empty task list when no Property data exists in IF" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Left(DataNotFoundError))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe emptyTaskSections
+      }
+
+      "return 'CheckNow' status for for all data when both Uk and Foreign data exists in IF" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Right(BusinessDetailsResponse(someProperty)))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe taskSections(JourneyStatus.CheckNow)
+      }
+
+      "return 'CheckNow' status for for just Uk data when only Uk data exists in IF" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Right(BusinessDetailsResponse(someUkProperty)))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe ukTaskSections(JourneyStatus.CheckNow)
+      }
+
+      "return 'CheckNow' status for for just Foreign data when only Foreign data exists in IF" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Right(BusinessDetailsResponse(someForeignProperty)))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe foreignTaskSections(JourneyStatus.CheckNow)
+      }
+    }
+
+    "All property types have Journey Answers defined" should {
+      "use Journey Answers when HMRC held data in IF" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Right(BusinessDetailsResponse(someProperty)))
+
+        await(testOnlyAdd(journeyResponse(IncomeSourceId("123456"), JourneyName.About, JourneyStatus.Completed)))
+        await(testOnlyAdd(journeyResponse(IncomeSourceId("123457"), JourneyName.ForeignPropertySelectCountry, JourneyStatus.Completed)))
+        await(testOnlyAdd(journeyResponse(IncomeSourceId("123458"), JourneyName.UkAndForeignPropertyAbout, JourneyStatus.Completed)))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe taskSections(JourneyStatus.Completed)
+      }
+
+      "use Journey Answers when no HMRC held data in IF" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Left(DataNotFoundError))
+
+        await(testOnlyAdd(journeyResponse(IncomeSourceId("123456"), JourneyName.About, JourneyStatus.Completed)))
+        await(testOnlyAdd(journeyResponse(IncomeSourceId("123457"), JourneyName.ForeignPropertySelectCountry, JourneyStatus.Completed)))
+        await(testOnlyAdd(journeyResponse(IncomeSourceId("123458"), JourneyName.UkAndForeignPropertyAbout, JourneyStatus.Completed)))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe taskSections(JourneyStatus.Completed)
+      }
+    }
+
+    "Only UkProperty has Journey Answers defined" should {
+      "use Journey Answers when HMRC held data in IF for Uk" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Right(BusinessDetailsResponse(someUkProperty)))
+
+        await(testOnlyAdd(journeyResponse(IncomeSourceId("123456"), JourneyName.About, JourneyStatus.Completed)))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe ukTaskSections(JourneyStatus.Completed)
+      }
+
+      "use mix of both Journey and IF data when IF contains all data" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Right(BusinessDetailsResponse(someProperty)))
+
+        await(testOnlyAdd(journeyResponse(IncomeSourceId("123456"), JourneyName.About, JourneyStatus.Completed)))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe mixedTaskSections
+      }
+
+      "use Journey Answers when no HMRC held data in IF" in new Test {
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Left(DataNotFoundError))
+
+        await(testOnlyAdd(journeyResponse(IncomeSourceId("123456"), JourneyName.About, JourneyStatus.Completed)))
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe ukTaskSections(JourneyStatus.Completed)
+      }
+    }
+
+    "Multiple users have data in journey answers" should {
+      "return Journey Answers of user with the matching mtditid" in new Test{
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Left(DataNotFoundError))
+
+        val otherUser: Future[Unit] = testOnlyAdd(journeyResponse(IncomeSourceId("123456"), JourneyName.About, JourneyStatus.Completed, mtditid = "12346"))
+        val currentUser: Future[Unit] = testOnlyAdd(journeyResponse(IncomeSourceId("123456"), JourneyName.About, JourneyStatus.InProgress))
+
+        await(otherUser)
+        await(currentUser)
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe ukTaskSections(JourneyStatus.InProgress)
+      }
+    }
+
+    "Same user has multiple entries for the same journey" should {
+      "return Journey Answers of Journey with the matching taxYear" in new Test{
+        await(removeAll(repository.collection))
+        mockGetBusinessDetails(nino, Left(DataNotFoundError))
+
+        val otherUser: Future[Unit] = testOnlyAdd(journeyResponse(IncomeSourceId("123456"), JourneyName.About, JourneyStatus.Completed, taxyear = 2023))
+        val currentUser: Future[Unit] = testOnlyAdd(journeyResponse(IncomeSourceId("123456"), JourneyName.About, JourneyStatus.InProgress))
+
+        await(otherUser)
+        await(currentUser)
+
+        val underTest: Future[Seq[TaskListSection]] = service.get(taxYear, nino, mtdItId)
+
+        await(underTest) shouldBe ukTaskSections(JourneyStatus.InProgress)
+      }
+    }
+  }
+}

--- a/test/utils/AppConfigStub.scala
+++ b/test/utils/AppConfigStub.scala
@@ -36,6 +36,8 @@ class AppConfigStub extends MockFactory {
     override lazy val ifBaseUrl: String = s"http://localhost:$wireMockPort"
     override lazy val ifEnvironment: String = environment
 
+    override lazy val propertyFrontendUrl = s"http://localhost:TEST/update-and-submit-income-tax-return/property"
+
     override def authorisationTokenFor(apiVersion: String): String = authorisationToken + s".$apiVersion"
   }
 }

--- a/test/utils/mocks/MockBusinessDetailsService.scala
+++ b/test/utils/mocks/MockBusinessDetailsService.scala
@@ -36,4 +36,11 @@ trait MockBusinessDetailsService extends MockFactory {
       .expects(nino, *)
       .returning(Future.successful(result))
   }
+
+  def mockGetBusinessDetailsException(nino: String,
+                                   result: Throwable
+                                  ): CallHandler2[String, HeaderCarrier, Future[Either[ServiceError, BusinessDetailsResponse]]] =
+    (mockIntegrationFrameworkService.getBusinessDetails(_: String)(_: HeaderCarrier))
+      .expects(nino, *)
+      .returning(Future.failed(result))
 }


### PR DESCRIPTION
- Added endpoint for taskList
- Added logic for retrieving data both from IF and Mongo journeys
- Added tests for all new files

Definitley feel like the ServiceSpec test set up could be done a little cleaner, though I'm not sure on the best process