### PR TITLE
SASS-7524 - 'Dividends from foreign companies' journey - BE-FE data fetch & display for the summary page

### DIFF
--- a/app/models/repository/ForeignIncomeMerger.scala
+++ b/app/models/repository/ForeignIncomeMerger.scala
@@ -53,7 +53,7 @@ object ForeignIncomeMerger {
                 specialWithholdingTax = dividends.specialWithholdingTax,
                 foreignTaxCreditRelief = dividends.foreignTaxCreditRelief,
                 taxableAmount = Some(dividends.taxableAmount),
-                foreignTaxDeductedFromDividendIncome = None
+                foreignTaxDeductedFromDividendIncome = Some(dividends.taxTakenOff.nonEmpty)
               )
           }
           Option.when(result.nonEmpty)(result)

--- a/test/models/repository/ForeignIncomeMergerSpec.scala
+++ b/test/models/repository/ForeignIncomeMergerSpec.scala
@@ -120,7 +120,7 @@ class ForeignIncomeMergerSpec extends UnitTest {
             specialWithholdingTax = Some(specialWithholdingTax),
             foreignTaxCreditRelief = Some(foreignTaxCreditRelief),
             taxableAmount = Some(taxableAmount),
-            foreignTaxDeductedFromDividendIncome = None
+            foreignTaxDeductedFromDividendIncome = Some(true)
           ))
         )
       }

--- a/test/services/ForeignIncomeServiceSpec.scala
+++ b/test/services/ForeignIncomeServiceSpec.scala
@@ -71,10 +71,10 @@ class ForeignIncomeServiceSpec
         Right(emptyForeignIncomeSubmission.copy(foreignDividend = Some(Seq(foreignDividend))))
     }
 
-    "return an empty foreign income submission when one is not present" in {
+    "return DataNotFoundError when one is not present" in {
       mockGetForeignIncomeSubmission(taxYear, nino, Right(None))
       await(underTest.getForeignIncomeSubmission(taxYear, nino).value) shouldBe
-        ForeignIncomeSubmission.emptyForeignIncomeSubmission.asRight[ServiceError]
+        DataNotFoundError.asLeft[ForeignIncomeSubmission]
     }
 
     "return ApiError when IF call fails" in {


### PR DESCRIPTION
Amended `getForeignIncomeSubmission` to return a DataNotFoundError instead of an empty submission when a submission is not found